### PR TITLE
Upgrade Hub/Lab, RStudio

### DIFF
--- a/.env
+++ b/.env
@@ -7,14 +7,14 @@
 # are not set in the shell environment.
 
 # To override these values, set the shell environment variables.
-# JUPYTERHUB_VERSION=2.3.1
-JUPYTERHUB_VERSION=1.5.0
+JUPYTERHUB_VERSION=2.3.1
+# JUPYTERHUB_VERSION=1.5.0
 
 # Assign a port for the hub to be hosted on.
 # To check the ports that are in use, run `docker ps`. 
 # Generally, picking a random number between 8000-9999 won't be an issue.
-PORT_NUM=8000
-HUB_NAME=hub
+PORT_NUM=9000
+HUB_NAME=new
 
 # Name of Docker network
 DOCKER_NETWORK_NAME=hub-network

--- a/Dockerfile.jupyterhub
+++ b/Dockerfile.jupyterhub
@@ -4,12 +4,13 @@ ARG JUPYTERHUB_VERSION
 FROM jupyterhub/jupyterhub-onbuild:$JUPYTERHUB_VERSION
 
 # Install dockerspawner, oauth, postgres
-RUN pip install psycopg2-binary~=2.7 && \
-    pip install --no-cache-dir \
+RUN pip3 install -U pip
+RUN pip3 install psycopg2-binary~=2.7 && \
+    pip3 install --no-cache-dir \
         oauthenticator==0.8.*
 
-RUN pip install jupyterhub-hashauthenticator dockerspawner==12.1.0
-RUN pip install jupyterhub-idle-culler
+RUN pip3 install dockerspawner==12.1.0
+RUN pip3 install jupyterhub-idle-culler
     
 # Copy TLS certificate and key
 #ENV SSL_CERT /srv/jupyterhub/secrets/jupyterhub.crt

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -83,7 +83,7 @@ ENABLE_DROPDOWN = True
 IMAGE_WHITELIST= {
     'default': f"{HUB_NAME}-user",
     'gpu': f"{HUB_NAME}-gpu-user",
-    'RStudio & Shiny': "r-image",
+    'RStudio & Shiny': f"{HUB_NAME}-r-user",
 }
 
 def default_url_fn(handler):
@@ -135,10 +135,27 @@ class MyDockerSpawner(DockerSpawner):
         self.image = image
 
         if self.image in (f"{HUB_NAME}-user", f"{HUB_NAME}-gpu-user"):
-            self.environment["VSCODE"] = "1"
+            self.default_url = "/vscode"
+            self.environment["VSCODE"] = "1"  # show icon
+            c.ServerProxy.servers = {
+                'vscode': {
+                     'command': [
+                               'code-server',
+                               '--auth', 'none',
+                               '--bind-addr', '0.0.0.0',
+                               '--port', '5000'
+                       ],
+                     'port': 5000,
+                     'absolute_url': False,
+                     'new_browser_tab': True,
+                     'launcher_entry': {
+                         'title': 'VSCode',
+                      },
+                }
+            }
 
-        if self.image == "r-image":
-            self.environment["RSTUDIO"] = "1"
+        if self.image == f"{HUB_NAME}-r-user":
+            self.default_url = "/rstudio"
 
     def grant_sudo(self):
         """
@@ -165,8 +182,8 @@ class MyDockerSpawner(DockerSpawner):
         Sets Jupyterlab as the default environment which users see.
         WARNING: Will not work if ~/.jupyter/jupyter_notebook_config.py exists.
         """
-        self.environment['JUPYTER_ENABLE_LAB'] = 'yes'
-        self.default_url = '/lab'
+        self.default_url = '/lab'  # seems to actually work now
+        # self.default_url = '/tree'
         # self.notebook_dir = '/home/jovyan/work'
 
     def update_volumes(self, group_list):

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -137,22 +137,6 @@ class MyDockerSpawner(DockerSpawner):
         if self.image in (f"{HUB_NAME}-user", f"{HUB_NAME}-gpu-user"):
             self.default_url = "/vscode"
             self.environment["VSCODE"] = "1"  # show icon
-            c.ServerProxy.servers = {
-                'vscode': {
-                     'command': [
-                               'code-server',
-                               '--auth', 'none',
-                               '--bind-addr', '0.0.0.0',
-                               '--port', '5000'
-                       ],
-                     'port': 5000,
-                     'absolute_url': False,
-                     'new_browser_tab': True,
-                     'launcher_entry': {
-                         'title': 'VSCode',
-                      },
-                }
-            }
 
         if self.image == f"{HUB_NAME}-r-user":
             self.default_url = "/rstudio"

--- a/makefile
+++ b/makefile
@@ -55,6 +55,9 @@ check-files: userlist secrets/postgres.env
 pull:
 	docker pull $(DOCKER_NOTEBOOK_IMAGE)
 
+pull_r:
+	docker pull docker.io/jupyter/r-notebook:hub-$(JUPYTERHUB_VERSION)
+
 notebook_image: pull singleuser/Dockerfile
 	docker build -t $(HUB_NAME)-user:latest \
 		--build-arg JUPYTERHUB_VERSION=$(JUPYTERHUB_VERSION) \
@@ -70,8 +73,11 @@ gpu_notebook_image: singleuser/Dockerfile.gpu
 build: check-files network volumes secrets/oauth.env secrets/postgres.env
 	docker-compose build
 
-r_image:
-	docker build -t r-image:latest -f singleuser/Dockerfile-R singleuser
+r_image: pull_r singleuser/Dockerfile-R
+	docker build -t $(HUB_NAME)-r-user:latest \
+		-f singleuser/Dockerfile-R \
+		--build-arg JUPYTERHUB_VERSION=$(JUPYTERHUB_VERSION) \
+		singleuser
 
 .PHONY: network volumes check-files pull notebook_image build
 

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -67,9 +67,10 @@ USER root
 ## CONFIG
 # Copy over config which creates launcher icons in jupyterlab
 COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
+COPY jupyter_server_config.py /home/$NB_USER/.jupyter/
 RUN mkdir -p /home/$NB_USER/.jupyter/lab/workspaces/
 COPY ./jupyterlab_settings /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab
-RUN chown -R $NB_USER:$NB_GUID /home/$NB_USER/.jupyter/lab
+RUN chown -R $NB_USER:$NB_GUID /home/$NB_USER/.jupyter
 USER $NB_UID
 
 # USER SETTINGS

--- a/singleuser/Dockerfile
+++ b/singleuser/Dockerfile
@@ -54,13 +54,15 @@ RUN /tmp/install_vscode.sh
 
 USER $NB_UID
 RUN mkdir -p /home/$NB_USER/.local/share/code-server/User/
+RUN mkdir -p /home/$NB_USER/.vscode/
 RUN code-server --install-extension ms-python.python
 RUN code-server --install-extension ms-toolsai.jupyter
 RUN code-server --install-extension hookyqr.beautify
 RUN code-server --install-extension eamodio.gitlens
 RUN code-server --install-extension mechatroner.rainbow-csv
 # RUN code-server --install-extension golang.go
-RUN echo '{ "python.defaultInterpreterPath": "conda", "telemetry.enableTelemetry": false, "telemetry.telemetryLevel": "off",}' > /home/$NB_USER/.local/share/code-server/User/settings.json
+RUN echo '{ "python.defaultInterpreterPath": "/opt/conda/bin/python",}' > /home/$NB_USER/.vscode/settings.json
+RUN echo '{ "telemetry.telemetryLevel": "off",}' > /home/$NB_USER/.local/share/code-server/User/settings.json
 
 
 USER root

--- a/singleuser/Dockerfile-R
+++ b/singleuser/Dockerfile-R
@@ -86,19 +86,6 @@ RUN apt-get -yqq update && \
 	apt-get -qq clean
 
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
-# I do not think these are necessary
-#RUN apt-get update && \
-#	apt-get install -y --no-install-recommends \
-#		libapparmor1 \
-#		libedit2 \
-#		lsb-release \
-#		psmisc \
-#		libssl1.0.0 \
-#		;
-
-# RUN curl https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.16.958-amd64.deb > /tmp/rshiny.deb && \
-#	apt-get install -y /tmp/rshiny.deb && \
-#	rm /tmp/rshiny.deb
 
 USER root
 # Cleanup
@@ -124,12 +111,10 @@ USER root
 ## CONFIG
 # Copy over config which creates launcher icons in jupyterlab
 COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
-COPY jupyter_server_config.py /home/$NB_USER/.jupyter/
 RUN mkdir -p /home/$NB_USER/.jupyter/lab/workspaces/
 COPY ./jupyterlab_settings /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab
 RUN chown -R $NB_USER:$NB_GUID /home/$NB_USER/.jupyter/lab
 
 USER $NB_UID
-# RUN python3 -m pip install jupyter-rsession-proxy jupyter_server_proxy
 # RUN python3 -m pip install jupyter-rsession-proxy jupyter_server_proxy
 RUN python3 -m pip install git+https://github.com/ryanlovett/jupyter-rsession-proxy@95759d85e95de6cb102702762d23f74ae2d46baa

--- a/singleuser/Dockerfile-R
+++ b/singleuser/Dockerfile-R
@@ -61,7 +61,7 @@ RUN set -x && \
 
 
 # RStudio
-RUN python3 -m pip install jupyter-rsession-proxy jupyter_server_proxy
+
 #RUN cd /tmp/ && \
 #	git clone --depth 1 https://github.com/jupyterhub/jupyter-server-proxy && \
 #	cd jupyter-server-proxy/jupyterlab-server-proxy && \
@@ -75,18 +75,17 @@ ENV RSTUDIO_DEB=https://download2.rstudio.org/server/jammy/amd64/rstudio-server-
 USER root
 # RUN apt-get install gdebi-core
 RUN apt-get -yqq update && \
-	apt-get install -yqq \
-		libssl3 \
-		libclang-dev \
-		&& \
-	curl --silent -L --fail ${RSTUDIO_DEB} > /tmp/rstudio.deb && \
-	apt-get install -y /tmp/rstudio.deb && \
-	rm /tmp/rstudio.deb && \
-	apt-get -qq purge && \
+ 	apt-get install -yqq \
+ 		libssl3 \
+ 		libclang-dev \
+ 		&& \
+ 	curl --silent -L --fail ${RSTUDIO_DEB} > /tmp/rstudio.deb && \
+ 	apt-get install -y /tmp/rstudio.deb && \
+ 	rm /tmp/rstudio.deb && \
+ 	apt-get -qq purge && \
 	apt-get -qq clean
 
 ENV PATH=$PATH:/usr/lib/rstudio-server/bin
-
 # I do not think these are necessary
 #RUN apt-get update && \
 #	apt-get install -y --no-install-recommends \
@@ -97,10 +96,11 @@ ENV PATH=$PATH:/usr/lib/rstudio-server/bin
 #		libssl1.0.0 \
 #		;
 
-RUN curl https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.16.958-amd64.deb > /tmp/rshiny.deb && \
-	apt-get install -y /tmp/rshiny.deb && \
-	rm /tmp/rshiny.deb
+# RUN curl https://download3.rstudio.org/ubuntu-14.04/x86_64/shiny-server-1.5.16.958-amd64.deb > /tmp/rshiny.deb && \
+#	apt-get install -y /tmp/rshiny.deb && \
+#	rm /tmp/rshiny.deb
 
+USER root
 # Cleanup
 RUN rm -rf $CONDA_DIR/share/jupyter/lab/staging && \
 	rm -rf /home/$NB_USER/.cache/yarn && \
@@ -124,8 +124,12 @@ USER root
 ## CONFIG
 # Copy over config which creates launcher icons in jupyterlab
 COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
+COPY jupyter_server_config.py /home/$NB_USER/.jupyter/
 RUN mkdir -p /home/$NB_USER/.jupyter/lab/workspaces/
 COPY ./jupyterlab_settings /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab
 RUN chown -R $NB_USER:$NB_GUID /home/$NB_USER/.jupyter/lab
 
 USER $NB_UID
+# RUN python3 -m pip install jupyter-rsession-proxy jupyter_server_proxy
+# RUN python3 -m pip install jupyter-rsession-proxy jupyter_server_proxy
+RUN python3 -m pip install git+https://github.com/ryanlovett/jupyter-rsession-proxy@95759d85e95de6cb102702762d23f74ae2d46baa

--- a/singleuser/Dockerfile-R
+++ b/singleuser/Dockerfile-R
@@ -1,4 +1,5 @@
-FROM docker.io/jupyter/r-notebook:hub-1.5.0
+ARG JUPYTERHUB_VERSION
+FROM docker.io/jupyter/r-notebook:hub-${JUPYTERHUB_VERSION}
 
 ###### R ENV #######
 USER root
@@ -18,35 +19,45 @@ RUN apt-get update && \
 # Fix for devtools https://github.com/conda-forge/r-devtools-feedstock/issues/4
 RUN ln -s /bin/tar /bin/gtar
 
-USER $NB_UID
-# R packages
-RUN conda install --quiet --yes \
-    'r-base=4.0.3' \
-    'r-caret=6.*' \
-    'r-crayon=1.4*' \
-    'r-devtools=2.3*' \
-    'r-forecast=8.13*' \
-    'r-hexbin=1.28*' \
-    'r-htmltools=0.5*' \
-    'r-htmlwidgets=1.5*' \
-    'r-irkernel=1.1*' \
-    'r-nycflights13=1.0*' \
-    'r-randomforest=4.6*' \
-    'r-rcurl=1.98*' \
-    'r-rmarkdown=2.6*' \
-    'r-rodbc=1.3*' \
-    'r-rsqlite=2.2*' \
-    'r-shiny=1.6*' \
-    'r-tidyverse=1.3*' \
-    'unixodbc=2.3.*' \
-    'r-tidymodels=0.1*'
-RUN \
-	conda clean --all -f -y && \
-	fix-permissions "${CONDA_DIR}" && \
-	fix-permissions "/home/${NB_USER}"
+USER ${NB_UID}
 
-# Install e1071 R package (dependency of the caret R package)
-#RUN conda install --quiet --yes r-e1071
+# R packages including IRKernel which gets installed globally.
+# r-e1071: dependency of the caret R package
+RUN mamba install --quiet --yes \
+    'r-base' \
+    'r-caret' \
+    'r-crayon' \
+    'r-devtools' \
+    'r-e1071' \
+    'r-forecast' \
+    'r-hexbin' \
+    'r-htmltools' \
+    'r-htmlwidgets' \
+    'r-irkernel' \
+    'r-nycflights13' \
+    'r-randomforest' \
+    'r-rcurl' \
+    'r-rmarkdown' \
+    'r-rodbc' \
+    'r-rsqlite' \
+    'r-shiny' \
+    'r-tidyverse' \
+    'unixodbc' && \
+    mamba clean --all -f -y && \
+    fix-permissions "${CONDA_DIR}" && \
+    fix-permissions "/home/${NB_USER}"
+
+# `r-tidymodels` is not easy to install under arm
+RUN set -x && \
+    arch=$(uname -m) && \
+    if [ "${arch}" == "x86_64" ]; then \
+        mamba install --quiet --yes \
+            'r-tidymodels' && \
+            mamba clean --all -f -y && \
+            fix-permissions "${CONDA_DIR}" && \
+            fix-permissions "/home/${NB_USER}"; \
+    fi;
+
 
 
 # RStudio
@@ -57,12 +68,18 @@ RUN python3 -m pip install jupyter-rsession-proxy jupyter_server_proxy
 #	npm install && npm run build && jupyter labextension link . && \
 #	npm run build && jupyter lab build
 
-
+# for hub 1.5.0:
+# https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.4.1106-amd64.deb
+ENV RSTUDIO_DEB=https://download2.rstudio.org/server/jammy/amd64/rstudio-server-2022.07.1-554-amd64.deb
 # install rstudio-server
 USER root
 # RUN apt-get install gdebi-core
 RUN apt-get -yqq update && \
-	curl --silent -L --fail https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.4.1106-amd64.deb > /tmp/rstudio.deb && \
+	apt-get install -yqq \
+		libssl3 \
+		libclang-dev \
+		&& \
+	curl --silent -L --fail ${RSTUDIO_DEB} > /tmp/rstudio.deb && \
 	apt-get install -y /tmp/rstudio.deb && \
 	rm /tmp/rstudio.deb && \
 	apt-get -qq purge && \
@@ -98,7 +115,7 @@ USER $NB_UID
 RUN  npm cache clean --force && \
 	rm -rf /home/$NB_USER/.node-gyp
 
-RUN conda clean --all -f -y && \
+RUN mamba clean --all -f -y && \
 	fix-permissions $CONDA_DIR && \
 	fix-permissions /home/$NB_USER
 

--- a/singleuser/Dockerfile.gpu
+++ b/singleuser/Dockerfile.gpu
@@ -61,13 +61,15 @@ RUN /tmp/install_vscode.sh
 
 USER $NB_UID
 RUN mkdir -p /home/$NB_USER/.local/share/code-server/User/
+RUN mkdir -p /home/$NB_USER/.vscode/
 RUN code-server --install-extension ms-python.python
 RUN code-server --install-extension ms-toolsai.jupyter
 RUN code-server --install-extension hookyqr.beautify
 RUN code-server --install-extension eamodio.gitlens
 RUN code-server --install-extension mechatroner.rainbow-csv
 # RUN code-server --install-extension golang.go
-RUN echo '{ "python.defaultInterpreterPath": "conda", "telemetry.enableTelemetry": false, "telemetry.telemetryLevel": "off",}' > /home/$NB_USER/.local/share/code-server/User/settings.json
+RUN echo '{ "python.defaultInterpreterPath": "/opt/conda/bin/python",}' > /home/$NB_USER/.vscode/settings.json
+RUN echo '{ "telemetry.telemetryLevel": "off",}' > /home/$NB_USER/.local/share/code-server/User/settings.json
 
 
 USER root

--- a/singleuser/Dockerfile.gpu
+++ b/singleuser/Dockerfile.gpu
@@ -74,6 +74,7 @@ USER root
 ## CONFIG
 # Copy over config which creates launcher icons in jupyterlab
 COPY jupyter_notebook_config.py /home/$NB_USER/.jupyter/
+COPY jupyter_server_config.py /home/$NB_USER/.jupyter/
 RUN mkdir -p /home/$NB_USER/.jupyter/lab/workspaces/
 COPY ./jupyterlab_settings /home/$NB_USER/.jupyter/lab/user-settings/@jupyterlab
 RUN chown -R $NB_USER:$NB_GUID /home/$NB_USER/.jupyter/lab

--- a/singleuser/jupyter_notebook_config.py
+++ b/singleuser/jupyter_notebook_config.py
@@ -1,28 +1,3 @@
 import os
 
 c.LatexConfig.latex_command = 'pdflatex'
-c.NotebookApp.default_url = '/lab'
-if os.environ.get("VSCODE", None):
-  c.NotebookApp.default_url = '/vscode'
-if os.environ.get("RSTUDIO", None):
-  c.NotebookApp.default_url = '/rstudio'
-
-# Jupyterlab icons can be created here to launch apps
-# that are included in the user's image.
-if os.environ.get("VSCODE", None):
-  c.ServerProxy.servers = {
-    'vscode': {
-      'command': [
-  		'code-server',
-  		'--auth', 'none',
-  		'--bind-addr', '0.0.0.0',
-  		'--port', '5000'
-  	],
-      'port': 5000,
-      'absolute_url': False,
-      'new_browser_tab': True,
-      'launcher_entry': {
-          'title': 'VSCode',
-          },
-    }
-  }

--- a/singleuser/jupyter_server_config.py
+++ b/singleuser/jupyter_server_config.py
@@ -1,0 +1,22 @@
+import os
+
+# Jupyterlab icons can be created here to launch apps
+# that are included in the user's image.
+if os.environ.get("VSCODE", None):
+  c.ServerProxy.servers = {
+    'vscode': {
+      'command': [
+  		'code-server',
+  		'--auth', 'none',
+  		'--bind-addr', '0.0.0.0',
+  		'--port', '5000'
+  	],
+      'port': 5000,
+      'absolute_url': False,
+      'new_browser_tab': True,
+      'launcher_entry': {
+          'title': 'VSCode',
+          },
+    }
+  }
+

--- a/singleuser/jupyterlab_settings/apputils-extension/themes.jupyterlab-settings
+++ b/singleuser/jupyterlab_settings/apputils-extension/themes.jupyterlab-settings
@@ -6,6 +6,5 @@
 
     // Selected Theme
     // Application-level visual styling theme
-    // "theme": "JupyterLab Dark"
-	"theme": "JupyterLab Miami Nights"
+    "theme": "JupyterLab Dark"
 }


### PR DESCRIPTION
only thing that can't be upgraded so far is `code-server` because the terminal seems to be broken with LibreWolf. However iirc `/lab` also didn't play nice with LibreWolf and Terminal. If that's the case, I'll go ahead and upgrade `code-server` as well and just stop using LibreWolf for jupyterhub.

- [ ] downgrading `code-server` (4.5.1) preserves LibreWolf functionality with Terminal in `/vscode`
- [ ] upgrading `code-server` (4.7.0) leads to functional notebooks and terminals in Chrome
- [ ] upgrading `code-server` (4.7.0) leads to functional notebooks and terminals in Safari
- [ ] upgrading `code-server` (4.7.0) leads to functional notebooks and terminals in LibreWolf

Some baseline checks:
- [ ] old hub terminal support in `/lab` under LibreWolf

still some final checks required (for code-server `4.5.1`):

- [ ] gpu image: torch / tflow gpu access
- [ ] `/rstudio`
  - [ ] can upgrade all packages in UI
  - [ ] launch demo shiny app
  - [ ] install new package
  - [ ] remove existing package
- [ ] smart-completion in `/lab`
- [ ] custom menu icons in `/lab`
  - [ ] gpu
  - [ ] rstudio
  - [ ] default
- [ ] custom menu icons in `/tree`
  - [ ] gpu
  - [ ] rstudio
  - [ ] default
- [ ] terminal support in `/lab`
  - [ ] Safari
  - [ ] Chrome
  - [ ] LibreWolf
- [ ] terminal support in `/vscode`
  - [ ] Safari
  - [ ] Chrome
  - [ ] LibreWolf
- [ ] notebook support in `/vscode`
  - [ ] Safari
  - [ ] Chrome
  - [ ] LibreWolf